### PR TITLE
feat: save each response in a single file to save the whole body (improve history requests)

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -22,7 +22,7 @@ type Context struct {
 	Env        *postman.Env
 	Envs       []postman.Env
 
-	CollectionHistoryRequests postman.CollectionHistoryItems
+	CollectionHistoryRequests postman.CollectionHistoryItemsLight
 	CMDsHistory               CMDHistories
 
 	Log   logger.Logger
@@ -59,12 +59,8 @@ func (c *Context) Clean() {
 	c.Env = nil
 }
 
-func (c *Context) AddCollectionHistoryRequest(i postman.CollectionHistoryItem) {
-	c.CollectionHistoryRequests = append(c.CollectionHistoryRequests, i)
-}
-
-func (c *Context) GetCollectionHistoryPath() string {
-	return GetHomeWorkspaceFilePath(c.WorkspaceName, c.CollectionName+".history.json")
+func (c *Context) GetCollectionHistoryPathFolder() string {
+	return GetHomeWorkspaceFilePath(c.WorkspaceName, c.CollectionName+"-history")
 }
 
 func (c *Context) GetCollectionPath() string {

--- a/internal/promptaction.go
+++ b/internal/promptaction.go
@@ -74,8 +74,8 @@ func FindPromptActionExecutor[T PromptExecutor](actions []PromptAction) *T {
 	return nil
 }
 
-// AddCMDHistory historises the command {cmd} (writes data on the disk).
-func AddCMDHistory(c Context, cmd string) {
+// HistoriseCommand historises the command {cmd} (writes data on the disk).
+func HistoriseCommand(c Context, cmd string) {
 	if cmd != "" {
 		histories := slicesutil.AddOrReplaceT[CMDHistory](c.CMDsHistory, NewCMDHistory(cmd), func(c CMDHistory) bool {
 			return c.CMD == cmd

--- a/internal/promptactions/promptpostman.go
+++ b/internal/promptactions/promptpostman.go
@@ -99,7 +99,7 @@ func (p PromptPostman) PromptExecutor(in []string) *internal.PromptCallback {
 		}
 
 		if slicesutil.Exist(in, workspaceParam) {
-			internal.AddCMDHistory(*p.c, strings.Join(in, " "))
+			internal.HistoriseCommand(*p.c, strings.Join(in, " "))
 
 			if bytes := p.call(workspacesEndpoint, apiKey); bytes != nil {
 				prettyprint.Print(prettyprint.SPrintJson(bytes, slicesutil.Exist(in, "--pretty")))
@@ -108,7 +108,7 @@ func (p PromptPostman) PromptExecutor(in []string) *internal.PromptCallback {
 		}
 
 		if slicesutil.Exist(in, syncParam) {
-			internal.AddCMDHistory(*p.c, strings.Join(in, " "))
+			internal.HistoriseCommand(*p.c, strings.Join(in, " "))
 
 			p.c.Print("INFO", "sync workspace with its collections and environments")
 			p.c.Print("INFO", "find workspace \"%s\" ...", slicesutil.FindNextEl(in, syncParam))

--- a/internal/promptexecutors/execs/displaybodyresponse.go
+++ b/internal/promptexecutors/execs/displaybodyresponse.go
@@ -37,32 +37,38 @@ func (d DisplayBodyResponseExec) Display(in []string, itemResponse *postman.Coll
 }
 
 // DisplayBodyResponse displays body of the response
-func (d DisplayBodyResponseExec) displayBodyResponse(in []string, itemResponse postman.CollectionHistoryItem) {
+func (d DisplayBodyResponseExec) displayBodyResponse(in []string, historyItem postman.CollectionHistoryItem) {
 	d.output(fmt.Sprintf(
 		"METHOD=%s STATUS=%s\nURL=%s",
-		prettyprint.FormatTextWithColor(itemResponse.Item.Request.Method, "G", false),
-		prettyprint.FormatTextWithColor(itemResponse.Status, "G", false),
-		prettyprint.FormatTextWithColor(itemResponse.Item.Request.Url.Get(itemResponse.Env, itemResponse.Params), "G", false),
+		prettyprint.FormatTextWithColor(historyItem.Item.Request.Method, "G", false),
+		prettyprint.FormatTextWithColor(historyItem.Status, "G", false),
+		prettyprint.FormatTextWithColor(historyItem.Item.Request.Url.Get(historyItem.Env, historyItem.Params), "G", false),
 	))
 	d.output("BODY=")
-	d.output(prettyprint.SPrintJson([]byte(itemResponse.Item.Request.Body.Get(itemResponse.Env, itemResponse.Params)), true))
+	d.output(prettyprint.SPrintJson([]byte(historyItem.Item.Request.Body.Get(historyItem.Env, historyItem.Params)), true))
 	d.output("____")
 	d.output(fmt.Sprintf(
 		"EXECUTED_AT=%s SIZE=%s TIME_(ms)=%s\nRESPONSE=",
-		prettyprint.FormatTextWithColor(itemResponse.ExecutedAt.Format("2006-01-02 15:04:05"), "G", false),
-		prettyprint.FormatTextWithColor(strconv.FormatInt(itemResponse.ContentLength, 10), "G", false),
-		prettyprint.FormatTextWithColor(strconv.FormatInt(itemResponse.TimeInMillis, 10), "G", false),
+		prettyprint.FormatTextWithColor(historyItem.ExecutedAt.Format("2006-01-02 15:04:05"), "G", false),
+		prettyprint.FormatTextWithColor(strconv.FormatInt(historyItem.ContentLength, 10), "G", false),
+		prettyprint.FormatTextWithColor(strconv.FormatInt(historyItem.TimeInMillis, 10), "G", false),
 	))
-	if len(itemResponse.Body) > 0 {
+	if historyItem.GetSize() > 0 {
 		if v := slicesutil.FindNextEl(in, "--search"); v != "" {
-			result := gjson.GetBytes(itemResponse.Data, v)
+			data := gjson.GetBytes(historyItem.Data, v).String()
 			d.output(prettyprint.SPrintJson(
-				[]byte(stringsutil.OrElse(result.String(), `"no result"`)),
+				[]byte(stringsutil.OrElse(data, `"no result"`)),
 				slicesutil.Exist(in, "--pretty")))
 		} else {
-			maxLimit := genericsutil.OrElse(-1, func() bool { return slicesutil.Exist(in, "--full") }, internal.HTTP_BODY_SIZE_LIMIT)
-			d.output(prettyprint.SPrintJson(itemResponse.GetBody(maxLimit), slicesutil.Exist(in, "--pretty")))
-			if itemResponse.Trunc && maxLimit != -1 && itemResponse.Data != nil {
+			maxLimit := genericsutil.OrElse(
+				-1, func() bool { return slicesutil.Exist(in, "--full") },
+				internal.HTTP_BODY_SIZE_LIMIT)
+
+			// display the response on output
+			d.output(prettyprint.SPrintJson(historyItem.GetData(maxLimit), slicesutil.Exist(in, "--pretty")))
+
+			truncated := len(historyItem.Data) > internal.HTTP_BODY_SIZE_LIMIT
+			if truncated && !slicesutil.Exist(in, "--full") {
 				d.output("\n...payload too big, the body has been truncated...")
 				d.output(fmt.Sprintf("(add option %s to display the full body or export it with %s)",
 					prettyprint.FormatTextWithColor("--full", "Y", false),

--- a/internal/promptexecutors/execs/securemode.go
+++ b/internal/promptexecutors/execs/securemode.go
@@ -132,9 +132,9 @@ func (s SecureModeExec) overwriteWorkspace(workspace, secret string) error {
 					return err
 				}
 			}
-			if strings.Contains(file.Name(), ".history.json") {
-				if err := overwriteT[postman.CollectionHistoryItems](filePath, s.tmpSuffix, secret, s.logger); err != nil {
-					s.c.Print("ERROR", "unable to overwrite collection history %s", filePath)
+			if file.IsDir() && strings.Contains(file.Name(), "-history") {
+				if err := os.RemoveAll(filePath); err != nil {
+					s.c.Print("ERROR", "unable to remove collection history %s", filePath)
 					return err
 				}
 			}


### PR DESCRIPTION
Context: I couldn't keep all the entire responses in the same file because the file was getting too big over time

So I changed my mind instead of remove history requests, I save each response in a single file to save the entire body and then keep the feature!