### PR TITLE
feat: split 'cmd' by a specific character and handle enclosed value

### DIFF
--- a/cmd/gcli-4postman/main.go
+++ b/cmd/gcli-4postman/main.go
@@ -219,8 +219,7 @@ func promptSuggest(d prompt.Document) []prompt.Suggest {
 
 func promptExecutor(in string) {
 	in = strings.TrimSpace(in)
-	tab := strings.Split(in, " ")
-
+	tab := stringsutil.Split(in, internal.SEP_CHARACTER, internal.ENCLOSE_CHARACTER)
 	if promptCallback != nil && promptCallback.IsAvailableAnswer(in) {
 		promptCallback.Callback(tab, actions)
 		promptCallback = nil

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.21.1
 
 require (
 	github.com/c-bata/go-prompt v0.2.6
-	github.com/go-logr/logr v1.4.1
+	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/gosimple/slug v1.14.0
 	github.com/jedib0t/go-pretty/v6 v6.5.9
-	github.com/joakim-ribier/go-utils v0.0.0-20240515194451-9e322e56bc18
+	github.com/joakim-ribier/go-utils v0.0.0-20240618194712-2a5834a5fe23
 	github.com/tidwall/gjson v1.17.1
 	github.com/tidwall/pretty v1.2.1
 	go.uber.org/zap v1.27.0
@@ -24,5 +24,5 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/c-bata/go-prompt v0.2.6 h1:POP+nrHE+DfLYx370bedwNhsqmpCUynWPxuHi0C5vZ
 github.com/c-bata/go-prompt v0.2.6/go.mod h1:/LMAke8wD2FsNu9EXNdHxNLbd9MedkPnCdfpU9wwHfY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
-github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
 github.com/go-logr/zapr v1.3.0/go.mod h1:YKepepNBd1u/oyhd/yQmtjVXmm9uML4IXUgMOwR8/Gg=
 github.com/gosimple/slug v1.14.0 h1:RtTL/71mJNDfpUbCOmnf/XFkzKRtD6wL6Uy+3akm4Es=
@@ -12,8 +12,10 @@ github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6
 github.com/gosimple/unidecode v1.0.1/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/jedib0t/go-pretty/v6 v6.5.9 h1:ACteMBRrrmm1gMsXe9PSTOClQ63IXDUt03H5U+UV8OU=
 github.com/jedib0t/go-pretty/v6 v6.5.9/go.mod h1:zbn98qrYlh95FIhwwsbIip0LYpwSG8SUOScs+v9/t0E=
-github.com/joakim-ribier/go-utils v0.0.0-20240515194451-9e322e56bc18 h1:qfHscqA/rrGoJoRlAypOk8PwjDaIswu0aqQqrBbAgA4=
-github.com/joakim-ribier/go-utils v0.0.0-20240515194451-9e322e56bc18/go.mod h1:vOyIyTMaA/0bCk5CqYTSco+TfZPPV7smeBv/NHbYoeE=
+github.com/joakim-ribier/go-utils v0.0.0-20240618175851-1bff718a3fb8 h1:kbk80GhnyhWYpx2fCyF9WLUDdijHkhmh9kGdBOVfE0c=
+github.com/joakim-ribier/go-utils v0.0.0-20240618175851-1bff718a3fb8/go.mod h1:dobaprlSn2y798AucceAPsuO2dAhzTnTXlR0Es1hXIk=
+github.com/joakim-ribier/go-utils v0.0.0-20240618194712-2a5834a5fe23 h1:rxG9AEYCf6+szmtNLME79ULgdZaEF1cXh8H9Wk0jZI8=
+github.com/joakim-ribier/go-utils v0.0.0-20240618194712-2a5834a5fe23/go.mod h1:dobaprlSn2y798AucceAPsuO2dAhzTnTXlR0Es1hXIk=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -64,7 +66,7 @@ golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
-golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cmdhistory.go
+++ b/internal/cmdhistory.go
@@ -22,10 +22,17 @@ func NewCMDHistory(cmd string) CMDHistory {
 
 // GetName returns the CMD history
 func (s CMDHistories) GetName() []string {
-	out := slicesutil.SortT[CMDHistory](s, func(c1, c2 CMDHistory) bool {
-		return c1.ExecutedAt.Before(c2.ExecutedAt)
+	out := slicesutil.SortT[CMDHistory](s, func(c1, c2 CMDHistory) int {
+		return c1.ExecutedAt.Compare(c2.ExecutedAt)
 	})
 	return slicesutil.TransformT[CMDHistory, string](out, func(c CMDHistory) (*string, error) {
 		return &c.CMD, nil
+	})
+}
+
+// SortByExecutedAt sorts the CMD by {ExecutedAt}
+func (s CMDHistories) SortByExecutedAt() []CMDHistory {
+	return slicesutil.SortT[CMDHistory](s, func(c1, c2 CMDHistory) int {
+		return c1.ExecutedAt.Compare(c2.ExecutedAt)
 	})
 }

--- a/internal/context.go
+++ b/internal/context.go
@@ -13,6 +13,9 @@ var APP_MODE = "user"
 var HTTP_BODY_SIZE_LIMIT = 5000
 var SECRET = ""
 var FILE_LOG = ""
+var SEP_CHARACTER = " "
+var ENCLOSE_CHARACTER = "'"
+var MAX_CMD_HISTORISE = 50
 
 type Context struct {
 	WorkspaceName  string

--- a/internal/postman/collectionhistoryitem.go
+++ b/internal/postman/collectionhistoryitem.go
@@ -105,7 +105,7 @@ func (c CollectionHistoryItemLight) BuildNameFile() string {
 
 // SortByExecutedAt sorts collection history items by {executedAt} field.
 func (c CollectionHistoryItemsLight) SortByExecutedAt() CollectionHistoryItemsLight {
-	return slicesutil.SortT[CollectionHistoryItemLight](c, func(i, j CollectionHistoryItemLight) bool {
-		return i.ExecutedAt.After(j.ExecutedAt)
+	return slicesutil.SortT[CollectionHistoryItemLight](c, func(i, j CollectionHistoryItemLight) int {
+		return i.ExecutedAt.Compare(j.ExecutedAt) * -1 // inverse order of `Compare` function
 	})
 }

--- a/internal/promptaction.go
+++ b/internal/promptaction.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"math"
 	"slices"
 
 	"github.com/c-bata/go-prompt"
@@ -77,9 +78,11 @@ func FindPromptActionExecutor[T PromptExecutor](actions []PromptAction) *T {
 // HistoriseCommand historises the command {cmd} (writes data on the disk).
 func HistoriseCommand(c Context, cmd string) {
 	if cmd != "" {
-		histories := slicesutil.AddOrReplaceT[CMDHistory](c.CMDsHistory, NewCMDHistory(cmd), func(c CMDHistory) bool {
+		var histories CMDHistories = slicesutil.AddOrReplaceT[CMDHistory](c.CMDsHistory, NewCMDHistory(cmd), func(c CMDHistory) bool {
 			return c.CMD == cmd
 		})
-		ioutil.Write[CMDHistories](histories, c.GetCMDHistoryPath(), SECRET)
+		ioutil.Write[CMDHistories](
+			histories.SortByExecutedAt()[:int(math.Min(float64(MAX_CMD_HISTORISE), float64(len(histories))))],
+			c.GetCMDHistoryPath(), SECRET)
 	}
 }

--- a/internal/promptactions/promptexecuterequest.go
+++ b/internal/promptactions/promptexecuterequest.go
@@ -175,9 +175,17 @@ func (p PromptExecuteRequest) PromptExecutor(in []string) *internal.PromptCallba
 					// refresh the context
 					p.c.CollectionHistoryRequests = append(p.c.CollectionHistoryRequests, response.ToLight())
 
-					internal.HistoriseCommand(*p.c, strings.Join(in, " "))
-					p.GetPromptExecutor().(promptexecutors.ExecuteRequestExecutor).HistoriseNewCollectionItem(*response)
+					// transform correctly the tab to the initial cmd
+					cmd := slicesutil.TransformT(in, func(v string) (*string, error) {
+						var a string = v
+						if strings.Contains(a, internal.SEP_CHARACTER) {
+							a = internal.ENCLOSE_CHARACTER + a + internal.ENCLOSE_CHARACTER
+						}
+						return &a, nil
+					})
+					internal.HistoriseCommand(*p.c, strings.Join(cmd, " "))
 
+					p.GetPromptExecutor().(promptexecutors.ExecuteRequestExecutor).HistoriseNewCollectionItem(*response)
 					execs.NewDisplayBodyResponseExec(p.logger, prettyprint.Print).Display(in, response)
 
 					if path := slicesutil.FindNextEl(in, "--save"); path != "" {

--- a/internal/promptactions/promptloadcollection.go
+++ b/internal/promptactions/promptloadcollection.go
@@ -64,8 +64,14 @@ func (p PromptLoadCollection) PromptSuggest(in []string, d prompt.Document) ([]p
 			suggests = append(suggests, prompt.Suggest{Text: fmt.Sprintf("%s/_%s", workspace, collection), Description: ""})
 		}
 	}
-	return slicesutil.SortT(suggests, func(s1, s2 prompt.Suggest) bool {
-		return strings.ToLower(s1.Text) < strings.ToLower(s2.Text)
+	return slicesutil.SortT(suggests, func(s1, s2 prompt.Suggest) int {
+		switch {
+		case strings.ToLower(s1.Text) < strings.ToLower(s2.Text):
+			return -1
+		case strings.ToLower(s1.Text) > strings.ToLower(s2.Text):
+			return +1
+		}
+		return 0
 	}), nil
 }
 


### PR DESCRIPTION
Handle the split between the enclosed characters.

Ex: The below cmd is splitted by `space` character but not between the two `'` characters 🚀 

````go
:h -u POST../create_case {{title}} 'created case from {GCLI-POSTMAN}'
// slices
[":h", "-u", "POST../create_case", "{{title}}", "created case from {GCLI-POSTMAN}"]